### PR TITLE
Add derivation for full BIP32 paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/taurusgroup/multi-party-sig
 
 go 1.14
 
+replace github.com/taurusgroup/multi-party-sig => ./
+
 require (
 	github.com/cronokirby/safenum v0.29.0
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/internal/bip32/bip32.go
+++ b/internal/bip32/bip32.go
@@ -9,6 +9,28 @@ import (
 	"github.com/taurusgroup/multi-party-sig/pkg/math/curve"
 )
 
+// DeriveMaster uses a secret seed to derive a scalar and chaining value.
+//
+// This scalar serves as the master secret key. Together with the chaining
+// value, it forms the extended master secret key.
+//
+// If an error is returned, this means that this seed is not useable, and a new
+// seed should be generated instead.
+func DeriveMaster(seed []byte) (*curve.Secp256k1Scalar, []byte, error) {
+	h := hmac.New(sha512.New, []byte("Bitcoin seed"))
+
+	_, _ = h.Write(seed)
+
+	out := h.Sum(nil)
+	scalar := new(curve.Secp256k1Scalar)
+	err := scalar.UnmarshalBinary(out[:32])
+	if err != nil || scalar.IsZero() {
+		return nil, nil, fmt.Errorf("bad seed: %s", seed)
+	}
+
+	return scalar, out[32:], nil
+}
+
 // DeriveScalar uses a public point, chaining value, and index, to derive a scalar and chaining value.
 //
 // This scalar should be added to the secret key.
@@ -39,4 +61,34 @@ func DeriveScalar(public *curve.Secp256k1Point, chaining []byte, i uint32) (*cur
 	}
 
 	return scalar, out[32:], nil
+}
+
+// DeriveScalarForPath uses a public point, chaining value, and path to derive
+// a scalar and chaining value.
+//
+// This scalar should be added to the secret key underlying the public point.
+//
+// If an error is returned, this means that an index in this path will not be
+// useable, and another path should be used instead.
+//
+// This function will panic if an index for a hardened key is used.
+func DeriveScalarForPath(public *curve.Secp256k1Point, chaining []byte, path Path) (*curve.Secp256k1Scalar, []byte, error) {
+	totalTweak := curve.Secp256k1{}.NewScalar()
+
+	for _, index := range path.indices {
+		totalTweakG := totalTweak.ActOnBase()
+		parentPublic := public.Add(totalTweakG).(*curve.Secp256k1Point)
+
+		var tweak *curve.Secp256k1Scalar
+		var err error
+		tweak, chaining, err = DeriveScalar(parentPublic, chaining, index)
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		totalTweak.Add(tweak)
+	}
+
+	return totalTweak.(*curve.Secp256k1Scalar), chaining, nil
 }

--- a/internal/bip32/path.go
+++ b/internal/bip32/path.go
@@ -1,0 +1,61 @@
+package bip32
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Path struct {
+	indices []uint32
+}
+
+func newIndex(relativeIndex uint32, hardened bool) uint32 {
+	hardenedBit := uint32(1 << 31)
+
+	if relativeIndex&hardenedBit == 1 {
+		panic(fmt.Sprintf("Expected index less than 2^31, found %d", relativeIndex))
+	}
+
+	if hardened {
+		return hardenedBit | relativeIndex
+	} else {
+		return relativeIndex
+	}
+}
+
+func indexFrom(spec string) (uint32, error) {
+	hardenedSuffix := "'"
+	hardened := strings.HasSuffix(spec, hardenedSuffix)
+	spec = strings.TrimSuffix(spec, hardenedSuffix)
+
+	base := 10
+	bitSize := 31
+	index, err := strconv.ParseUint(spec, base, bitSize)
+	if err != nil {
+		var i uint32
+		return i, err
+	}
+
+	return newIndex(uint32(index), hardened), nil
+}
+
+func PathFrom(spec string) (Path, error) {
+	var indices []uint32
+
+	if len(spec) == 0 {
+		return Path{indices: indices}, nil
+	}
+
+	for _, s := range strings.Split(spec, "/") {
+		h, err := indexFrom(s)
+		if err != nil {
+			var p Path
+			return p, err
+		}
+
+		indices = append(indices, h)
+	}
+
+	return Path{indices: indices}, nil
+}

--- a/internal/bip32/path_test.go
+++ b/internal/bip32/path_test.go
@@ -1,0 +1,107 @@
+package bip32
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/taurusgroup/multi-party-sig/pkg/math/curve"
+)
+
+func (left *Path) eq(right *Path) bool {
+	if len(left.indices) != len(right.indices) {
+		return false
+	}
+
+	for i, index := range left.indices {
+		if index != right.indices[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestPathFrom(t *testing.T) {
+	spec := "44'/0/0'/348"
+
+	result, err := PathFrom(spec)
+
+	if err != nil {
+		t.Errorf("") // FIXME
+	}
+
+	desired := Path{indices: []uint32{
+		newIndex(44, true),
+		newIndex(0, false),
+		newIndex(0, true),
+		newIndex(348, false),
+	}}
+
+	if !result.eq(&desired) {
+		t.Errorf("The BIP32 path %s fails to parse correctly", spec)
+	}
+}
+
+// Test cases are taken from
+// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#Test_Vectors.
+// A test case key string `keyString` was decoded as follows:
+//
+//	import "github.com/btcsuite/btcutil/base58"
+//
+//	payload, version, err := base58.CheckDecode(keyString)
+//	chainKey := payload[12:12+32]
+//	paddedPrivateOrPublicKeyBytes := payload[12+32+1:]
+//
+// This extraction has been precomputed to avoid adding the base58 dependency.
+func TestDerive(t *testing.T) {
+	seedString := "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542"
+	seed, err := hex.DecodeString(seedString)
+	if err != nil {
+		panic("Bug in test: Expected seed to be a hex string")
+	}
+
+	// Extracted from "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U"
+	masterChainKey, err := hex.DecodeString("60499f801b896d83179a4374aeb7822aaeaceaa0db1f85ee3e904c4defbd9689")
+	if err != nil {
+		panic("Bug in test: Expected to be a hex string")
+	}
+
+	// Extracted from "xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt"
+	childChainKey, err := hex.DecodeString("f0909affaa7ee7abe5dd4e100598d4dc53cd709d5a5c2cac40e7412f232f7c9c")
+	if err != nil {
+		panic("Bug in test: Expected to be a hex string")
+	}
+
+	computedMasterPrivateKey, computedMasterChainKey, err := DeriveMaster(seed)
+	if err != nil {
+		panic("Expected derivation of master key from seed to succeed")
+	}
+
+	// We do not yet check that the computed master private key is correct.
+	//
+	// It is a `curve.Scalar`, which hides its underlying value.
+	// To check correctness requires accessing its bits
+	// or converting the correct bits to a `curve.Scalar`
+	// and then calling the method `curve.Scalar.Equal`.
+	_ = computedMasterPrivateKey
+
+	if !bytes.Equal(masterChainKey, computedMasterChainKey) {
+		t.Errorf("Expected chain key \n\t0x%x but have \n\t0x%x", masterChainKey, computedMasterChainKey)
+	}
+
+	path, err := PathFrom("0")
+	computedAdjust, computedChildChainKey, err := DeriveScalarForPath(
+		computedMasterPrivateKey.ActOnBase().(*curve.Secp256k1Point),
+		computedMasterChainKey,
+		path)
+	if err != nil {
+		panic("Expected derivation of child from master key to succeed")
+	}
+
+	if !bytes.Equal(childChainKey, computedChildChainKey) {
+		t.Errorf("Expected chain key \n\t0x%x but have \n\t0x%x", childChainKey, computedChildChainKey)
+	}
+
+	_ = computedAdjust
+}

--- a/protocols/frost/keygen/config.go
+++ b/protocols/frost/keygen/config.go
@@ -85,7 +85,7 @@ func (r *Config) Derive(adjust curve.Scalar, newChainKey []byte) (*Config, error
 
 // DeriveChild adjusts the shares to represent the derived public key at a certain index.
 //
-// This will panic if the group is not curve.Secp256k1
+// # This will panic if the group is not curve.Secp256k1
 //
 // This derivation works according to BIP-32, see:
 // https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
@@ -95,6 +95,28 @@ func (r *Config) DeriveChild(i uint32) (*Config, error) {
 		return nil, errors.New("DeriveChild called on non secp256k1 curve")
 	}
 	scalar, newChainKey, err := bip32.DeriveScalar(publicKey, r.ChainKey, i)
+	if err != nil {
+		return nil, err
+	}
+	return r.Derive(scalar, newChainKey)
+}
+
+// DeriveDescendant adjusts the shares to represent the derived public key at a certain path.
+//
+// # This will panic if the group is not curve.Secp256k1
+//
+// This derivation works according to BIP-32, see:
+// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+func (r *Config) DeriveDescendant(pathSpec string) (*Config, error) {
+	publicKey, ok := r.PublicKey.(*curve.Secp256k1Point)
+	if !ok {
+		return nil, errors.New("DeriveChild called on non secp256k1 curve")
+	}
+	path, err := bip32.PathFrom(pathSpec)
+	if err != nil {
+		return nil, err
+	}
+	scalar, newChainKey, err := bip32.DeriveScalarForPath(publicKey, r.ChainKey, path)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +163,7 @@ func (r *TaprootConfig) Clone() *TaprootConfig {
 		PrivateShare:       curve.Secp256k1{}.NewScalar().Set(r.PrivateShare).(*curve.Secp256k1Scalar),
 		PublicKey:          publicKeyCopy,
 		ChainKey:           chainKeyCopy,
-		VerificationShares: r.VerificationShares,
+		VerificationShares: verificationSharesCopy,
 	}
 }
 
@@ -205,6 +227,31 @@ func (r *TaprootConfig) DeriveChild(i uint32) (*TaprootConfig, error) {
 		return nil, err
 	}
 	scalar, newChainKey, err := bip32.DeriveScalar(publicKey, r.ChainKey, i)
+	if err != nil {
+		return nil, err
+	}
+	return r.Derive(scalar, newChainKey)
+}
+
+// DeriveDescendant adjusts the shares to represent the derived public key at a certain path.
+//
+// This derivation works according to BIP-32, see:
+// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+//
+// Note that to do this derivation, we interpret the Taproot key as an "old"
+// ECDSA key, with the y coordinate byte set to 0x02. We also only look at the x
+// coordinate of the derived public key, making sure that the corresponding secret
+// key matches the version of this point with an even y coordinate.
+func (r *TaprootConfig) DeriveDescendant(pathSpec string) (*TaprootConfig, error) {
+	publicKey, err := curve.Secp256k1{}.LiftX(r.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	path, err := bip32.PathFrom(pathSpec)
+	if err != nil {
+		return nil, err
+	}
+	scalar, newChainKey, err := bip32.DeriveScalarForPath(publicKey, r.ChainKey, path)
 	if err != nil {
 		return nil, err
 	}

--- a/protocols/frost/keygen/keygen.go
+++ b/protocols/frost/keygen/keygen.go
@@ -34,9 +34,9 @@ func StartKeygenCommon(taproot bool, group curve.Curve, participants []party.ID,
 			Group:            group,
 		}
 		if taproot {
-			info.ProtocolID = protocolID
-		} else {
 			info.ProtocolID = protocolIDTaproot
+		} else {
+			info.ProtocolID = protocolID
 		}
 
 		helper, err := round.NewSession(info, sessionID, nil)

--- a/protocols/frost/keygen/round1.go
+++ b/protocols/frost/keygen/round1.go
@@ -99,7 +99,7 @@ func (r *round1) Finalize(out chan<- *round.Message) (round.Session, error) {
 		Sigma_i = zksch.NewProof(r.Helper.HashForID(r.SelfID()), a_i0_times_G, a_i0, nil)
 	}
 
-	// 3. "Every participant Pᵢ computes a public comment Φᵢ = <ϕᵢ₀, ..., ϕᵢₜ>
+	// 3. "Every participant Pᵢ computes a public commitment Φᵢ = <ϕᵢ₀, ..., ϕᵢₜ>
 	// where ϕᵢⱼ = aᵢⱼ * G."
 	//
 	// Note: I've once again adjusted the threshold indices, I've also taken


### PR DESCRIPTION
There is already support for deriving a child key given its integer index. This adds support for deriving a child key given a path, such as "44'/0'/0'/0/0", which is made up of many indices.